### PR TITLE
[ELIXPO] [PATCH] Fix the link of the stargazwrs in the repo readme to show the image center aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,7 @@ For developers looking to contribute, this project is built on a modern, fast, a
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for elixpo/accounts.elixpo](https://reporoster.com/stars/elixpo/accounts.elixpo)](https://github.com/elixpo/accounts.elixpo/stargazers)
+<div align="center">
+  [![Stargazers repo roster for elixpo/accounts.elixpo](https://reporoster.com/stars/elixpo/accounts.elixpo)](https://github.com/elixpo/accounts.elixpo/stargazers)
+</div>
 


### PR DESCRIPTION
Hey @Circuit-Overtime, here's the PR for your request.

## 🎯 What this does
This PR center-aligns the Stargazers roster image in the project README. It wraps the existing roster link and image in a center-aligned div to improve the visual presentation of the repository's landing page.

## 💡 Why
The stargazers roster was previously left-aligned, which looked inconsistent with the other centered elements in the header. This change ensures a more balanced and professional layout as requested in #25.

## 🛠️ Changes
- `README.md`: Wrapped the Stargazers repo roster markdown in a `<div align="center">` tag to center the generated image.

## 🧪 How I tested it
- Ran `./biome.sh ci` to ensure formatting and linting are clean.
- Manually verified the HTML structure in the README.

---
@Circuit-Overtime Fixes #25