### PR TITLE
[ELIXPO] docs: Add PWA branding and mascot concepts (#44)

### DIFF
--- a/socials/prompts/branding_concepts.md
+++ b/socials/prompts/branding_concepts.md
@@ -1,0 +1,42 @@
+# Elixpo Accounts PWA & Social Branding Concepts
+
+This document outlines the core branding concepts, color themes, and mascot ideas for the `accounts.elixpo` Progressive Web App and social media presence.
+
+## 1. Color Theme & Vibe
+Based on the project's `theme.js`, the branding is deeply rooted in a modern, cyber-security, developer-centric aesthetic:
+* **Primary Backgrounds:** Deep, dark forest-slate (`#141a16`). It feels premium, secure, and developer-centric.
+* **Primary Accents (The "Glow"):** Neon Lime (`#a3e635`) and Sage Green (`#86efac`). These colors scream "success," "verified," and "access granted," which is perfect for an identity provider.
+* **Secondary Accents:** Honey/Amber (`#fbbf24`) and soft Lavender (`#c4b5fd`) to add depth.
+* **Visual Style:** **Glassmorphism & Cyber-Sec**. Frosted glass effects (translucent dark cards with blurred backgrounds), subtle radial glows, and crisp geometric typography (Space Grotesk).
+
+## 2. Mascot Ideas (The "Accounts Panda")
+Since this is an OAuth 2.0 Identity Provider, the core mascot (a panda) must embody security, trust, and access. Here are four stylistic approaches:
+
+**Demo Mascot Design Link:** [https://canva.link/6pawcnhm53phb88](https://canva.link/6pawcnhm53phb88)
+
+### Option A: The Cyber-Security / Vault Panda (3D Tech-Wear)
+* **Concept:** A sleek, approachable, but highly technical gatekeeper.
+* **Visual Elements:** Holding a glowing holographic "Access Key" (in neon lime). Wearing a sleek tech-wear jacket or futuristic security lanyard. AR glasses reflecting binary or lock symbols.
+* **Style:** 3D rendered, slightly stylized (modern 3D tech-art), with rim lighting highlighting the lime and sage green against a dark background.
+
+### Option B: The Mystical Gatekeeper (Studio Ghibli Style)
+* **Concept:** Trust, ancient wisdom, and magical protection.
+* **Visual Elements:** A soft, massive, friendly guardian panda holding a glowing, magical lime-green lantern (representing the Auth Token). Glowing sage-green fireflies (data packets) float around.
+* **Style:** 2D anime style, soft watercolor-style backgrounds (dark starry night or deep forest), warm, nostalgic, and deeply comforting.
+
+### Option C: The Retro Sysadmin (16-Bit Pixel Art Style)
+* **Concept:** Tech, developer-focused, retro-computing, edge runtime.
+* **Visual Elements:** An elite sysadmin panda at a retro terminal, wearing a backwards cap or headset. Screen reflects neon lime (`#a3e635`) binary code. Or an isometric view holding a giant glowing pixelated key.
+* **Style:** High-quality 16-bit or isometric pixel art. Deep dark background, sharp glowing pixel edges, subtle CRT scanlines. Nostalgic and geeky.
+
+### Option D: The Origami Vault (Minimalist / Modern Line-Art Style)
+* **Concept:** Modern, clean, enterprise-ready, scalable.
+* **Visual Elements:** The panda is constructed out of intersecting geometric shapes (shields, hexagons, keyholes). The primary lines are crisp white, with vibrant lime and sage gradients filling specific facets.
+* **Style:** Flat vector illustration (modern SaaS aesthetic). Sleek, dark frosted glass background. Lightning-fast and highly professional.
+
+## 3. Style of Social Media / PR Images
+* **Layout:** "Bento box" grid layouts or sleek, single-focus cinematic shots.
+* **Backgrounds:** Deep dark backgrounds (`#141a16`) with abstract geometric patterns or soft lime radial gradients.
+* **Foreground:** Frosted glass cards (`rgba(255,255,255,0.05)` with blur) displaying code snippets, checkmarks, or padlocks.
+* **Typography:** Big, bold, clean sans-serif text for announcements ("NEW OAUTH RELEASE").
+* **Mascot Placement:** Off-center, interacting with floating UI elements.

--- a/socials/prompts/branding_concepts.md
+++ b/socials/prompts/branding_concepts.md
@@ -10,7 +10,7 @@ Based on the project's `theme.js`, the branding is deeply rooted in a modern, cy
 * **Visual Style:** **Glassmorphism & Cyber-Sec**. Frosted glass effects (translucent dark cards with blurred backgrounds), subtle radial glows, and crisp geometric typography (Space Grotesk).
 
 ## 2. Mascot Ideas (The "Accounts Panda")
-Since this is an OAuth 2.0 Identity Provider, the core mascot (a panda) must embody security, trust, and access. Here are four stylistic approaches:
+Since this is an OAuth 2.0 Identity Provider, the core mascot (a panda) must embody security, trust, and access. Here are four stylistic approaches
 
 **Demo Mascot Design Link:** [https://canva.link/6pawcnhm53phb88](https://canva.link/6pawcnhm53phb88)
 


### PR DESCRIPTION
## Changes
- Added `socials/prompts/branding_concepts.md` establishing the core color theme (#141a16, #a3e635, #86efac) and visual style.
- Outlined 4 stylistic approaches for the new Accounts Panda mascot (3D Tech-Wear, Ghibli, Pixel Art, Origami Vault).
- Included Canva demo link for the base mascot design.
- Defined bento-box layout and typography rules for social media assets.

---
Fixes #44
