### PR TITLE
[FEAT]: Improve login age UX and created dashboard for non-gated access

### DIFF
--- a/app/(auth)/authorize/page.tsx
+++ b/app/(auth)/authorize/page.tsx
@@ -228,8 +228,7 @@ function AuthorizeContent() {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    background:
-                        "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                    background: "transparent",
                     padding: 16,
                 }}
             >
@@ -308,8 +307,7 @@ function AuthorizeContent() {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    background:
-                        "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                    background: "transparent",
                 }}
             >
                 <div style={{ textAlign: "center" }}>
@@ -341,8 +339,7 @@ function AuthorizeContent() {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background:
-                    "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                background: "transparent",
                 padding: 16,
             }}
         >

--- a/app/(auth)/error/page.tsx
+++ b/app/(auth)/error/page.tsx
@@ -33,8 +33,7 @@ const ErrorContent = () => {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background:
-                    "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                background: "transparent",
                 p: 2,
             }}
         >

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -221,8 +221,7 @@ function ForgotPasswordContent() {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    background:
-                        "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                    background: "transparent",
                 }}
             >
                 <CircularProgress sx={{ color: "#9b7bf7" }} />
@@ -237,8 +236,7 @@ function ForgotPasswordContent() {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background:
-                    "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                background: "transparent",
                 p: 2,
             }}
         >
@@ -485,8 +483,7 @@ export default function ForgotPasswordPage() {
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
-                        background:
-                            "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                        background: "transparent",
                     }}
                 >
                     <CircularProgress sx={{ color: "#9b7bf7" }} />

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -139,7 +139,7 @@ function ForgotPasswordContent() {
         e.preventDefault();
         setError("");
 
-        if (!otp || otp.length !== 6) {
+        if (otp?.length !== 6) {
             setError("Please enter a valid 6-digit OTP");
             return;
         }

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,3 +1,5 @@
+import { Box } from "@mui/material";
+import BackgroundAurora from "../components/background-aurora";
 import Navbar from "../components/navbar";
 
 export default function AuthLayout({
@@ -6,9 +8,12 @@ export default function AuthLayout({
     children: React.ReactNode;
 }) {
     return (
-        <>
-            <Navbar />
-            {children}
-        </>
+        <Box sx={{ position: "relative", minHeight: "100vh" }}>
+            <BackgroundAurora variant="auth" />
+            <Box sx={{ position: "relative", zIndex: 1 }}>
+                <Navbar />
+                {children}
+            </Box>
+        </Box>
     );
 }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -138,8 +138,7 @@ const LoginContent = () => {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    background:
-                        "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                    background: "transparent",
                 }}
             >
                 <CircularProgress sx={{ color: "#9b7bf7" }} />
@@ -154,8 +153,7 @@ const LoginContent = () => {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background:
-                    "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                background: "transparent",
                 p: 2,
             }}
         >

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -110,8 +110,7 @@ const RegisterContent = () => {
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background:
-                    "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                background: "transparent",
                 p: 2,
             }}
         >

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,39 +1,51 @@
 "use client";
 
+import BoltIcon from "@mui/icons-material/Bolt";
+import CodeIcon from "@mui/icons-material/Code";
 import GitHubIcon from "@mui/icons-material/GitHub";
-import { Box, Typography } from "@mui/material";
+import HubIcon from "@mui/icons-material/Hub";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import SensorsIcon from "@mui/icons-material/Sensors";
+import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import Link from "next/link";
+import BackgroundAurora from "../components/background-aurora";
+import Footer from "../components/footer";
+import Navbar from "../components/navbar";
+
+const ACCENT = "#9b7bf7";
+const REPO_URL = "https://github.com/elixpo/accounts.elixpo";
 
 const features = [
     {
-        icon: "🔐",
+        icon: LockOutlinedIcon,
         title: "OAuth 2.0 Provider",
-        desc: "Industry-standard authorization code flow with PKCE support. Let users sign in to your app with their Elixpo account.",
+        desc: "Industry-standard authorization code flow with PKCE. Let users sign in to any app with an Elixpo account.",
     },
     {
-        icon: "⚡",
-        title: "Edge-First Architecture",
-        desc: "Runs entirely on Cloudflare Workers and D1 — globally distributed, sub-50ms latency, zero cold starts.",
+        icon: BoltIcon,
+        title: "Edge-first architecture",
+        desc: "Runs on Cloudflare Workers + D1 — globally distributed, sub-50ms latency, zero cold starts.",
     },
     {
-        icon: "🛡️",
-        title: "Secure by Default",
-        desc: "EdDSA JWT tokens, HMAC-SHA256 webhook signatures, httpOnly cookies, and Web Crypto API — no Node.js crypto dependencies.",
+        icon: ShieldOutlinedIcon,
+        title: "Secure by default",
+        desc: "EdDSA JWTs, HMAC-SHA256 webhook signatures, httpOnly cookies, Web Crypto API — no Node crypto dependencies.",
     },
     {
-        icon: "🔗",
-        title: "Multi-Provider SSO",
-        desc: "Users can register and sign in with email/password, Google, or GitHub — with automatic account linking.",
+        icon: HubIcon,
+        title: "Multi-provider SSO",
+        desc: "Email + password, Google, or GitHub — with automatic account linking across providers.",
     },
     {
-        icon: "🧑‍💻",
-        title: "Developer Portal",
-        desc: "Register OAuth apps, manage redirect URIs, view usage stats, and configure webhooks — all from your dashboard.",
+        icon: CodeIcon,
+        title: "Developer portal",
+        desc: "Register OAuth apps, manage redirect URIs, view usage stats, and configure webhooks from your dashboard.",
     },
     {
-        icon: "📡",
+        icon: SensorsIcon,
         title: "Webhooks",
-        desc: "Receive real-time HTTP notifications for platform events like user signups, OAuth authorizations, and token revocations.",
+        desc: "Real-time HTTP notifications for platform events — signups, OAuth authorizations, token revocations.",
     },
 ];
 
@@ -42,178 +54,259 @@ export default function AboutPage() {
         <Box
             sx={{
                 minHeight: "100vh",
-                background:
-                    "linear-gradient(135deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                color: "#f5f5f4",
+                display: "flex",
+                flexDirection: "column",
+                position: "relative",
             }}
         >
-            {/* Hero */}
-            <Box
-                sx={{
-                    maxWidth: "900px",
-                    mx: "auto",
-                    px: 3,
-                    pt: 10,
-                    pb: 8,
-                    textAlign: "center",
-                }}
-            >
-                <Box
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        gap: 2,
-                        mb: 3,
-                    }}
-                >
-                    <Box
-                        component="img"
-                        src="/LOGO/logo.png"
-                        alt="Elixpo"
-                        sx={{ height: 48, width: 48, borderRadius: "12px" }}
-                    />
-                    <Typography
-                        variant="h3"
-                        sx={{
-                            fontWeight: 800,
-                            color: "#f5f5f4",
-                            letterSpacing: "-0.02em",
-                        }}
-                    >
-                        Elixpo Accounts
-                    </Typography>
-                </Box>
-                <Typography
-                    sx={{
-                        color: "rgba(255,255,255,0.5)",
-                        fontSize: "1.15rem",
-                        maxWidth: "600px",
-                        mx: "auto",
-                        lineHeight: 1.7,
-                    }}
-                >
-                    A modern OAuth 2.0 identity provider built on the edge.
-                    Authenticate users across your services with a single,
-                    secure account.
-                </Typography>
+            <BackgroundAurora variant="warm" />
 
-                <Box
-                    sx={{
-                        display: "flex",
-                        gap: 2,
-                        justifyContent: "center",
-                        mt: 4,
-                    }}
-                >
-                    <Box
-                        component={Link}
-                        href="/login"
-                        sx={{
-                            px: 3,
-                            py: 1.5,
-                            borderRadius: "10px",
-                            background: "rgba(155, 123, 247, 0.15)",
-                            color: "#9b7bf7",
-                            border: "1px solid rgba(155, 123, 247, 0.3)",
-                            fontWeight: 600,
-                            fontSize: "0.95rem",
-                            textDecoration: "none",
-                            transition: "all 0.2s",
-                            "&:hover": {
-                                background: "rgba(155, 123, 247, 0.25)",
-                                borderColor: "rgba(155, 123, 247, 0.5)",
-                            },
-                        }}
-                    >
-                        Get Started
-                    </Box>
-                </Box>
+            <Box sx={{ position: "relative", zIndex: 1 }}>
+                <Navbar />
             </Box>
 
-            {/* Features Grid */}
-            <Box sx={{ maxWidth: "1000px", mx: "auto", px: 3, pb: 8 }}>
+            <Box
+                component="main"
+                sx={{
+                    flex: 1,
+                    maxWidth: "1100px",
+                    width: "100%",
+                    mx: "auto",
+                    px: { xs: 2.5, md: 4 },
+                    pt: { xs: 4, md: 6 },
+                    pb: { xs: 6, md: 8 },
+                    position: "relative",
+                    zIndex: 1,
+                }}
+            >
+                <Stack
+                    spacing={2.5}
+                    alignItems="center"
+                    textAlign="center"
+                    sx={{ maxWidth: "780px", mx: "auto" }}
+                >
+                    <Stack
+                        direction="row"
+                        alignItems="center"
+                        spacing={1.5}
+                        sx={{ mb: 0.5 }}
+                    >
+                        <Box
+                            component="img"
+                            src="/LOGO/logo.png"
+                            alt="Elixpo"
+                            sx={{
+                                height: 42,
+                                width: 42,
+                                borderRadius: "11px",
+                            }}
+                        />
+                        <Chip
+                            label="About"
+                            size="small"
+                            sx={{
+                                bgcolor: "rgba(155, 123, 247, 0.12)",
+                                color: ACCENT,
+                                border: "1px solid rgba(155, 123, 247, 0.3)",
+                                fontWeight: 600,
+                                letterSpacing: "0.04em",
+                                fontSize: "0.7rem",
+                                height: 24,
+                            }}
+                        />
+                    </Stack>
+
+                    <Typography
+                        component="h1"
+                        sx={{
+                            fontWeight: 800,
+                            fontSize: { xs: "2.2rem", md: "3.1rem" },
+                            lineHeight: 1.1,
+                            letterSpacing: "-0.025em",
+                            background:
+                                "linear-gradient(180deg, #ffffff 0%, #d4cce6 100%)",
+                            WebkitBackgroundClip: "text",
+                            WebkitTextFillColor: "transparent",
+                        }}
+                    >
+                        A modern identity layer{" "}
+                        <Box component="span" sx={{ color: ACCENT }}>
+                            for any app.
+                        </Box>
+                    </Typography>
+                    <Typography
+                        sx={{
+                            color: "rgba(255,255,255,0.65)",
+                            fontSize: { xs: "1rem", md: "1.1rem" },
+                            maxWidth: "620px",
+                            lineHeight: 1.6,
+                            fontFamily: "var(--font-geist-sans)",
+                        }}
+                    >
+                        Elixpo Accounts is an open OAuth 2.0 identity provider
+                        built on the edge. Authenticate users across your
+                        services with a single, secure account — yours or
+                        anyone's.
+                    </Typography>
+
+                    <Stack
+                        direction={{ xs: "column", sm: "row" }}
+                        spacing={1.5}
+                        sx={{ pt: 1 }}
+                    >
+                        <Button
+                            component={Link}
+                            href="/login"
+                            sx={{
+                                textTransform: "none",
+                                fontWeight: 600,
+                                fontSize: "1rem",
+                                color: "#fff",
+                                background:
+                                    "linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)",
+                                borderRadius: "12px",
+                                px: 3,
+                                py: 1.2,
+                                boxShadow: "0 8px 24px rgba(155,123,247,0.32)",
+                                transition: "all 0.2s ease",
+                                "&:hover": {
+                                    background:
+                                        "linear-gradient(135deg, #b094ff 0%, #8a6dff 100%)",
+                                    boxShadow:
+                                        "0 12px 32px rgba(155,123,247,0.45)",
+                                    transform: "translateY(-1px)",
+                                },
+                            }}
+                        >
+                            Get started
+                        </Button>
+                        <Button
+                            component="a"
+                            href={REPO_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            startIcon={<GitHubIcon />}
+                            sx={{
+                                textTransform: "none",
+                                fontWeight: 500,
+                                fontSize: "1rem",
+                                color: "rgba(255,255,255,0.85)",
+                                border: "1px solid rgba(255,255,255,0.12)",
+                                borderRadius: "12px",
+                                px: 3,
+                                py: 1.2,
+                                "&:hover": {
+                                    borderColor: "rgba(155,123,247,0.4)",
+                                    background: "rgba(255,255,255,0.04)",
+                                },
+                            }}
+                        >
+                            View source
+                        </Button>
+                    </Stack>
+                </Stack>
+
                 <Box
                     sx={{
                         display: "grid",
-                        gridTemplateColumns: { xs: "1fr", md: "1fr 1fr 1fr" },
-                        gap: 2,
+                        gridTemplateColumns: {
+                            xs: "1fr",
+                            sm: "1fr 1fr",
+                            md: "1fr 1fr 1fr",
+                        },
+                        gap: 2.5,
+                        mt: { xs: 6, md: 9 },
                     }}
                 >
-                    {features.map((f) => (
+                    {features.map(({ icon: Icon, title, desc }) => (
                         <Box
-                            key={f.title}
+                            key={title}
                             sx={{
                                 p: 3,
                                 borderRadius: "16px",
-                                bgcolor: "rgba(255,255,255,0.03)",
-                                border: "1px solid rgba(255,255,255,0.06)",
-                                transition: "all 0.25s ease",
+                                background:
+                                    "linear-gradient(135deg, rgba(255,255,255,0.045) 0%, rgba(255,255,255,0.015) 100%)",
+                                border: "1px solid rgba(255,255,255,0.08)",
+                                backdropFilter: "blur(20px)",
+                                transition:
+                                    "border-color 0.2s ease, transform 0.2s ease",
                                 "&:hover": {
-                                    borderColor: "rgba(155, 123, 247,0.3)",
-                                    bgcolor: "rgba(155, 123, 247,0.03)",
+                                    borderColor: "rgba(155,123,247,0.3)",
                                     transform: "translateY(-2px)",
                                 },
                             }}
                         >
-                            <Box sx={{ fontSize: "1.5rem", mb: 1.5 }}>
-                                {f.icon}
+                            <Box
+                                sx={{
+                                    display: "inline-flex",
+                                    p: 1.1,
+                                    borderRadius: "10px",
+                                    background: "rgba(155,123,247,0.12)",
+                                    border: "1px solid rgba(155,123,247,0.25)",
+                                    mb: 1.8,
+                                }}
+                            >
+                                <Icon sx={{ color: ACCENT, fontSize: 20 }} />
                             </Box>
                             <Typography
                                 sx={{
-                                    color: "#f5f5f4",
                                     fontWeight: 700,
-                                    fontSize: "0.95rem",
-                                    mb: 1,
+                                    fontSize: "1rem",
+                                    color: "#f5f5f4",
+                                    mb: 0.8,
+                                    fontFamily: "var(--font-geist-sans)",
                                 }}
                             >
-                                {f.title}
+                                {title}
                             </Typography>
                             <Typography
                                 sx={{
-                                    color: "rgba(255,255,255,0.4)",
-                                    fontSize: "0.83rem",
-                                    lineHeight: 1.65,
+                                    color: "rgba(255,255,255,0.6)",
+                                    fontSize: "0.88rem",
+                                    lineHeight: 1.6,
+                                    fontFamily: "var(--font-geist-mono)",
                                 }}
                             >
-                                {f.desc}
+                                {desc}
                             </Typography>
                         </Box>
                     ))}
                 </Box>
-            </Box>
 
-            {/* Open Source Banner */}
-            <Box sx={{ maxWidth: "1000px", mx: "auto", px: 3, pb: 8 }}>
                 <Box
                     sx={{
+                        mt: { xs: 6, md: 9 },
+                        p: { xs: 3.5, md: 5 },
+                        borderRadius: "20px",
+                        background:
+                            "linear-gradient(135deg, rgba(155,123,247,0.12) 0%, rgba(255,124,201,0.06) 100%)",
+                        border: "1px solid rgba(155,123,247,0.25)",
                         display: "flex",
                         flexDirection: { xs: "column", md: "row" },
-                        alignItems: "center",
+                        alignItems: { xs: "flex-start", md: "center" },
                         justifyContent: "space-between",
                         gap: 3,
-                        p: 4,
-                        borderRadius: "20px",
-                        bgcolor: "rgba(255,255,255,0.025)",
-                        border: "1px solid rgba(255,255,255,0.06)",
                     }}
                 >
-                    <Box sx={{ textAlign: { xs: "center", md: "left" } }}>
+                    <Box>
                         <Typography
                             sx={{
                                 color: "#f5f5f4",
                                 fontWeight: 700,
-                                fontSize: "1.1rem",
-                                mb: 0.75,
+                                fontSize: { xs: "1.15rem", md: "1.3rem" },
+                                mb: 0.8,
+                                letterSpacing: "-0.015em",
                             }}
                         >
-                            Fully Open Source
+                            Fully open source
                         </Typography>
                         <Typography
                             sx={{
-                                color: "rgba(255,255,255,0.4)",
-                                fontSize: "0.9rem",
+                                color: "rgba(255,255,255,0.62)",
+                                fontSize: "0.93rem",
                                 lineHeight: 1.6,
-                                maxWidth: 480,
+                                maxWidth: 520,
                             }}
                         >
                             Elixpo Accounts is open source and free to
@@ -221,53 +314,35 @@ export default function AboutPage() {
                             your own instance.
                         </Typography>
                     </Box>
-                    <Box
+                    <Button
                         component="a"
-                        href="https://github.com/elixpo/elixpoaccounts"
+                        href={REPO_URL}
                         target="_blank"
                         rel="noopener noreferrer"
+                        startIcon={<GitHubIcon />}
                         sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 1.25,
-                            px: 3,
-                            py: 1.5,
-                            borderRadius: "12px",
-                            bgcolor: "rgba(255,255,255,0.06)",
-                            border: "1px solid rgba(255,255,255,0.1)",
-                            color: "#f5f5f4",
+                            textTransform: "none",
                             fontWeight: 600,
                             fontSize: "0.95rem",
-                            textDecoration: "none",
+                            color: "#f5f5f4",
+                            background: "rgba(255,255,255,0.06)",
+                            border: "1px solid rgba(255,255,255,0.12)",
+                            borderRadius: "12px",
+                            px: 2.6,
+                            py: 1.1,
                             flexShrink: 0,
-                            transition: "all 0.2s",
                             "&:hover": {
-                                bgcolor: "rgba(255,255,255,0.1)",
-                                borderColor: "rgba(255,255,255,0.2)",
+                                background: "rgba(155,123,247,0.12)",
+                                borderColor: "rgba(155,123,247,0.4)",
                             },
                         }}
                     >
-                        <GitHubIcon sx={{ fontSize: "1.25rem" }} />
                         View on GitHub
-                    </Box>
+                    </Button>
                 </Box>
             </Box>
 
-            {/* Footer */}
-            <Box
-                sx={{
-                    borderTop: "1px solid rgba(255,255,255,0.05)",
-                    py: 4,
-                    textAlign: "center",
-                }}
-            >
-                <Typography
-                    sx={{ color: "rgba(255,255,255,0.2)", fontSize: "0.8rem" }}
-                >
-                    Elixpo Accounts &mdash; Open source &middot; Built on
-                    Cloudflare Pages
-                </Typography>
-            </Box>
+            <Footer />
         </Box>
     );
 }

--- a/app/admin/api-keys/page.tsx
+++ b/app/admin/api-keys/page.tsx
@@ -95,7 +95,7 @@ export default function ApiKeysPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
         fetchApiKeys();
-    }, []);
+    }, [fetchApiKeys]);
 
     const fetchApiKeys = async () => {
         try {
@@ -116,8 +116,6 @@ export default function ApiKeysPage() {
             setLoading(false);
         }
     };
-
-    
 
     const handleCreateApiKey = async () => {
         if (!formData.name.trim()) {

--- a/app/api/admin/invite/route.ts
+++ b/app/api/admin/invite/route.ts
@@ -190,7 +190,7 @@ export async function PATCH(request: NextRequest) {
 
         const { verifyJWT } = await import("@/lib/jwt");
         const payload = await verifyJWT(cookieToken);
-        if (!payload || payload.type !== "access") {
+        if (payload?.type !== "access") {
             return NextResponse.json(
                 { error: "Invalid session" },
                 { status: 401 },

--- a/app/api/auth/authorize/route.ts
+++ b/app/api/auth/authorize/route.ts
@@ -210,7 +210,7 @@ export async function POST(request: NextRequest) {
         }
 
         const jwtPayload = await verifyJWT(accessToken);
-        if (!jwtPayload || jwtPayload.type !== "access") {
+        if (jwtPayload?.type !== "access") {
             return NextResponse.json(
                 {
                     error: "unauthorized",

--- a/app/api/auth/connected-services/route.ts
+++ b/app/api/auth/connected-services/route.ts
@@ -10,7 +10,7 @@ async function getAuth(request: NextRequest) {
         request.headers.get("authorization")?.replace("Bearer ", "");
     if (!token) return null;
     const payload = await verifyJWT(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
     return payload;
 }
 
@@ -85,7 +85,9 @@ export async function DELETE(request: NextRequest) {
             .run();
 
         // Notify the app to purge the user's data (first-party apps only).
-        const { fireRevocationWebhook } = await import("@/lib/revocation-webhook");
+        const { fireRevocationWebhook } = await import(
+            "@/lib/revocation-webhook"
+        );
         await fireRevocationWebhook(clientId, auth.sub, "app.revoked");
 
         return NextResponse.json({ success: true });

--- a/app/api/auth/delete-account/route.ts
+++ b/app/api/auth/delete-account/route.ts
@@ -37,7 +37,9 @@ export async function POST(request: NextRequest) {
                 )
                 .bind(userId)
                 .all();
-            connectedClientIds = (conn.results || []).map((r: any) => r.client_id);
+            connectedClientIds = (conn.results || []).map(
+                (r: any) => r.client_id,
+            );
         } catch {}
 
         // Delete in order: dependent tables first, then user
@@ -71,8 +73,14 @@ export async function POST(request: NextRequest) {
 
         // Notify connected first-party apps to hard-purge the user's data.
         try {
-            const { fireRevocationToAll } = await import("@/lib/revocation-webhook");
-            await fireRevocationToAll(connectedClientIds, userId, "user.deleted");
+            const { fireRevocationToAll } = await import(
+                "@/lib/revocation-webhook"
+            );
+            await fireRevocationToAll(
+                connectedClientIds,
+                userId,
+                "user.deleted",
+            );
         } catch {}
 
         // Clear auth cookies

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -35,7 +35,7 @@ async function getUserIdentity(db: D1Database, userId: string) {
 async function tryAutoRefresh(_request: NextRequest, refreshToken: string) {
     try {
         const payload = await verifyJWT(refreshToken);
-        if (!payload || payload.type !== "refresh") {
+        if (payload?.type !== "refresh") {
             return NextResponse.json(
                 { error: "Invalid refresh token" },
                 { status: 401 },
@@ -174,15 +174,11 @@ export async function GET(request: NextRequest) {
         const payload = await verifyJWT(accessToken);
 
         // Access token expired but refresh token cookie exists — auto-refresh
-        if (
-            (!payload || payload.type !== "access") &&
-            refreshTokenCookie &&
-            cookieToken
-        ) {
+        if (payload?.type !== "access" && refreshTokenCookie && cookieToken) {
             return await tryAutoRefresh(request, refreshTokenCookie);
         }
 
-        if (!payload || payload.type !== "access") {
+        if (payload?.type !== "access") {
             return NextResponse.json(
                 { error: "Invalid token" },
                 { status: 401 },
@@ -264,7 +260,7 @@ export async function PATCH(request: NextRequest) {
         }
 
         const payload = await verifyJWT(accessToken);
-        if (!payload || payload.type !== "access") {
+        if (payload?.type !== "access") {
             return NextResponse.json(
                 { error: "Invalid token" },
                 { status: 401 },
@@ -411,14 +407,12 @@ export async function PATCH(request: NextRequest) {
                             { status: 400 },
                         );
                     }
-                    const changeCount =
-                        currentUser.username_change_count || 0;
+                    const changeCount = currentUser.username_change_count || 0;
                     const lastChanged = currentUser.username_changed_at
                         ? new Date(currentUser.username_changed_at).getTime()
                         : 0;
                     const twoWeeksMs = 14 * 24 * 60 * 60 * 1000;
-                    const windowExpired =
-                        Date.now() - lastChanged > twoWeeksMs;
+                    const windowExpired = Date.now() - lastChanged > twoWeeksMs;
                     const effectiveCount = windowExpired ? 0 : changeCount;
                     if (effectiveCount >= 2) {
                         const resetDate = new Date(lastChanged + twoWeeksMs);

--- a/app/api/auth/notification-preferences/route.ts
+++ b/app/api/auth/notification-preferences/route.ts
@@ -14,7 +14,7 @@ async function getAuth(request: NextRequest) {
         request.headers.get("authorization")?.replace("Bearer ", "");
     if (!token) return null;
     const payload = await verifyJWT(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
     return payload;
 }
 

--- a/app/api/auth/oauth-clients/route.ts
+++ b/app/api/auth/oauth-clients/route.ts
@@ -13,7 +13,7 @@ async function getAuth(request: NextRequest) {
         request.headers.get("authorization")?.replace("Bearer ", "");
     if (!token) return null;
     const payload = await verifyJWT(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
     return payload;
 }
 

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
         // Verify refresh token
         const payload = await verifyJWT(refreshToken);
 
-        if (!payload || payload.type !== "refresh") {
+        if (payload?.type !== "refresh") {
             return NextResponse.json(
                 { error: "Invalid or expired refresh token" },
                 { status: 401 },

--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -241,7 +241,7 @@ export async function POST(request: NextRequest) {
 
             try {
                 const payload = await verifyJWT(refresh_token);
-                if (!payload || payload.type !== "refresh") {
+                if (payload?.type !== "refresh") {
                     return NextResponse.json(
                         {
                             error: "invalid_grant",

--- a/app/api/auth/username/check/route.ts
+++ b/app/api/auth/username/check/route.ts
@@ -26,12 +26,19 @@ export async function GET(request: NextRequest) {
             `username:taken:${username}`,
         );
         if (cached?.taken) {
-            return NextResponse.json({ available: false, reason: "That username is taken." });
+            return NextResponse.json({
+                available: false,
+                reason: "That username is taken.",
+            });
         }
 
         const db = await getDatabase();
         const taken = await isUsernameTaken(db, username);
-        await cacheSet(`username:taken:${username}`, { taken }, taken ? 86400 : 30);
+        await cacheSet(
+            `username:taken:${username}`,
+            { taken },
+            taken ? 86400 : 30,
+        );
 
         return NextResponse.json(
             taken
@@ -41,6 +48,9 @@ export async function GET(request: NextRequest) {
     } catch {
         // On infra failure, don't claim availability — let the authoritative
         // UNIQUE constraint reject at write time.
-        return NextResponse.json({ available: false, reason: "Could not check right now." });
+        return NextResponse.json({
+            available: false,
+            reason: "Could not check right now.",
+        });
     }
 }

--- a/app/api/auth/webhooks/[id]/route.ts
+++ b/app/api/auth/webhooks/[id]/route.ts
@@ -10,7 +10,7 @@ async function getAuth(request: NextRequest) {
         request.headers.get("authorization")?.replace("Bearer ", "");
     if (!token) return null;
     const payload = await verifyJWT(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
     return payload;
 }
 

--- a/app/api/auth/webhooks/[id]/test/route.ts
+++ b/app/api/auth/webhooks/[id]/test/route.ts
@@ -10,7 +10,7 @@ async function getAuth(request: NextRequest) {
         request.headers.get("authorization")?.replace("Bearer ", "");
     if (!token) return null;
     const payload = await verifyJWT(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
     return payload;
 }
 

--- a/app/api/auth/webhooks/route.ts
+++ b/app/api/auth/webhooks/route.ts
@@ -10,7 +10,7 @@ async function getAuth(request: NextRequest) {
         request.headers.get("authorization")?.replace("Bearer ", "");
     if (!token) return null;
     const payload = await verifyJWT(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
     return payload;
 }
 

--- a/app/api/internal/send-email/route.ts
+++ b/app/api/internal/send-email/route.ts
@@ -113,7 +113,7 @@ async function sendAdminNotificationEmail(
         <p style="color: #f1f5f9; margin: 4px 0; font-weight: 600;">${resourceName}</p>
       </div>`
               : ""
-      }
+}
       <hr style="border-color: #1e293b; margin: 24px 0;" />
       <p style="color: #475569; font-size: 12px;">Elixpo Accounts — Admin Notifications</p>
     </div>

--- a/app/components/background-aurora.tsx
+++ b/app/components/background-aurora.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Box } from "@mui/material";
+
+type Variant = "default" | "auth" | "warm";
+
+const PALETTES: Record<Variant, [string, string, string]> = {
+    default: ["#9b7bf7", "#5fb6ff", "#7c5cff"],
+    auth: ["#9b7bf7", "#ff7cc9", "#5fb6ff"],
+    warm: ["#ff8a5b", "#ff5b9a", "#9b7bf7"],
+};
+
+interface Props {
+    variant?: Variant;
+}
+
+const BackgroundAurora = ({ variant = "default" }: Props) => {
+    const [a, b, c] = PALETTES[variant];
+
+    return (
+        <Box
+            aria-hidden
+            sx={{
+                position: "fixed",
+                inset: 0,
+                zIndex: 0,
+                pointerEvents: "none",
+                overflow: "hidden",
+                background:
+                    "linear-gradient(180deg, #0b0d12 0%, #11151c 50%, #0b0d12 100%)",
+                "&::before, &::after": {
+                    content: '""',
+                    position: "absolute",
+                    width: "55vmax",
+                    height: "55vmax",
+                    borderRadius: "50%",
+                    filter: "blur(110px)",
+                    opacity: 0.32,
+                    willChange: "transform",
+                },
+                "&::before": {
+                    top: "-20vmax",
+                    left: "-15vmax",
+                    background: `radial-gradient(circle, ${a} 0%, transparent 65%)`,
+                    animation: "auroraDriftA 28s ease-in-out infinite",
+                },
+                "&::after": {
+                    bottom: "-25vmax",
+                    right: "-20vmax",
+                    background: `radial-gradient(circle, ${b} 0%, transparent 65%)`,
+                    animation: "auroraDriftB 34s ease-in-out infinite",
+                },
+            }}
+        >
+            <Box
+                aria-hidden
+                sx={{
+                    position: "absolute",
+                    top: "40%",
+                    left: "55%",
+                    width: "40vmax",
+                    height: "40vmax",
+                    borderRadius: "50%",
+                    filter: "blur(120px)",
+                    opacity: 0.18,
+                    background: `radial-gradient(circle, ${c} 0%, transparent 65%)`,
+                    animation: "auroraDriftC 40s ease-in-out infinite",
+                    willChange: "transform",
+                }}
+            />
+        </Box>
+    );
+};
+
+export default BackgroundAurora;

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -226,7 +226,8 @@ const Footer = () => {
                                             color: "#fff",
                                             borderColor:
                                                 "rgba(155,123,247,0.45)",
-                                            background: "rgba(155,123,247,0.08)",
+                                            background:
+                                                "rgba(155,123,247,0.08)",
                                         },
                                     }}
                                 >

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+import {
+    Box,
+    Button,
+    IconButton,
+    Snackbar,
+    Stack,
+    Tooltip,
+    Typography,
+} from "@mui/material";
+import Link from "next/link";
+import { useState } from "react";
+
+const ACCENT = "#9b7bf7";
+const EMAIL = "hello@elixpo.com";
+const REPO_URL = "https://github.com/elixpo/accounts.elixpo";
+
+const navLinks = [
+    { label: "Sign in", href: "/login" },
+    { label: "About", href: "/about" },
+    { label: "Docs", href: "/docs" },
+    { label: "Integrator guide", href: "/docs" },
+];
+
+const Footer = () => {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopyEmail = async () => {
+        try {
+            await navigator.clipboard.writeText(EMAIL);
+            setCopied(true);
+        } catch {
+            // Fallback for older browsers / non-secure contexts
+            const ta = document.createElement("textarea");
+            ta.value = EMAIL;
+            document.body.appendChild(ta);
+            ta.select();
+            try {
+                document.execCommand("copy");
+                setCopied(true);
+            } catch {
+                window.location.href = `mailto:${EMAIL}`;
+            }
+            document.body.removeChild(ta);
+        }
+    };
+
+    return (
+        <Box
+            component="footer"
+            sx={{
+                position: "relative",
+                zIndex: 1,
+                mt: { xs: 6, md: 10 },
+                borderTop: "1px solid rgba(255,255,255,0.08)",
+                background:
+                    "linear-gradient(180deg, rgba(11,13,18,0) 0%, rgba(11,13,18,0.4) 100%)",
+                backdropFilter: "blur(12px)",
+            }}
+        >
+            <Box
+                sx={{
+                    maxWidth: "1200px",
+                    mx: "auto",
+                    px: { xs: 2.5, md: 4 },
+                    py: { xs: 5, md: 6 },
+                }}
+            >
+                <Stack
+                    direction={{ xs: "column", md: "row" }}
+                    spacing={{ xs: 4, md: 6 }}
+                    justifyContent="space-between"
+                    alignItems={{ xs: "flex-start", md: "flex-start" }}
+                >
+                    <Box sx={{ maxWidth: 360 }}>
+                        <Stack
+                            direction="row"
+                            alignItems="center"
+                            spacing={1.2}
+                            sx={{ mb: 1.2 }}
+                        >
+                            <Box
+                                component="img"
+                                src="/LOGO/logo.png"
+                                alt="Elixpo"
+                                sx={{
+                                    height: 28,
+                                    width: 28,
+                                    borderRadius: "8px",
+                                }}
+                            />
+                            <Typography
+                                sx={{
+                                    fontWeight: 700,
+                                    fontSize: "1rem",
+                                    color: "#f4f4f6",
+                                    letterSpacing: "-0.01em",
+                                }}
+                            >
+                                Elixpo{" "}
+                                <Box component="span" sx={{ color: ACCENT }}>
+                                    Accounts
+                                </Box>
+                            </Typography>
+                        </Stack>
+                        <Typography
+                            sx={{
+                                color: "rgba(255,255,255,0.55)",
+                                fontSize: "0.88rem",
+                                lineHeight: 1.6,
+                            }}
+                        >
+                            Open OAuth 2.0 single sign-on, built on the edge.
+                            Drop it into any app — Elixpo or yours — and let
+                            users sign in with one account.
+                        </Typography>
+                    </Box>
+
+                    <Stack
+                        direction={{ xs: "column", sm: "row" }}
+                        spacing={{ xs: 3, sm: 6 }}
+                    >
+                        <Box>
+                            <Typography
+                                sx={{
+                                    color: "rgba(255,255,255,0.45)",
+                                    fontSize: "0.72rem",
+                                    fontWeight: 700,
+                                    letterSpacing: "0.1em",
+                                    textTransform: "uppercase",
+                                    mb: 1.4,
+                                }}
+                            >
+                                Navigate
+                            </Typography>
+                            <Stack spacing={1.1}>
+                                {navLinks.map((l) => (
+                                    <Link
+                                        key={l.label}
+                                        href={l.href}
+                                        style={{
+                                            color: "rgba(255,255,255,0.75)",
+                                            textDecoration: "none",
+                                            fontSize: "0.88rem",
+                                        }}
+                                    >
+                                        {l.label}
+                                    </Link>
+                                ))}
+                            </Stack>
+                        </Box>
+
+                        <Box>
+                            <Typography
+                                sx={{
+                                    color: "rgba(255,255,255,0.45)",
+                                    fontSize: "0.72rem",
+                                    fontWeight: 700,
+                                    letterSpacing: "0.1em",
+                                    textTransform: "uppercase",
+                                    mb: 1.4,
+                                }}
+                            >
+                                Get in touch
+                            </Typography>
+                            <Stack spacing={1.5} alignItems="flex-start">
+                                <Tooltip
+                                    title={copied ? "Copied!" : "Click to copy"}
+                                    arrow
+                                >
+                                    <Button
+                                        onClick={handleCopyEmail}
+                                        startIcon={
+                                            <MailOutlineIcon
+                                                sx={{ fontSize: 18 }}
+                                            />
+                                        }
+                                        endIcon={
+                                            <ContentCopyIcon
+                                                sx={{
+                                                    fontSize: 14,
+                                                    color: "rgba(255,255,255,0.5)",
+                                                }}
+                                            />
+                                        }
+                                        sx={{
+                                            textTransform: "none",
+                                            color: "rgba(255,255,255,0.85)",
+                                            fontFamily:
+                                                "var(--font-geist-mono)",
+                                            fontSize: "0.85rem",
+                                            border: "1px solid rgba(255,255,255,0.12)",
+                                            borderRadius: "10px",
+                                            px: 1.5,
+                                            py: 0.6,
+                                            transition: "all 0.18s ease",
+                                            "&:hover": {
+                                                color: "#fff",
+                                                borderColor:
+                                                    "rgba(155,123,247,0.45)",
+                                                background:
+                                                    "rgba(155,123,247,0.08)",
+                                            },
+                                        }}
+                                    >
+                                        {EMAIL}
+                                    </Button>
+                                </Tooltip>
+                                <IconButton
+                                    component="a"
+                                    href={REPO_URL}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label="View on GitHub"
+                                    sx={{
+                                        color: "rgba(244,244,246,0.85)",
+                                        border: "1px solid rgba(255,255,255,0.1)",
+                                        borderRadius: "10px",
+                                        width: 36,
+                                        height: 36,
+                                        "&:hover": {
+                                            color: "#fff",
+                                            borderColor:
+                                                "rgba(155,123,247,0.45)",
+                                            background: "rgba(155,123,247,0.08)",
+                                        },
+                                    }}
+                                >
+                                    <GitHubIcon sx={{ fontSize: 18 }} />
+                                </IconButton>
+                            </Stack>
+                        </Box>
+                    </Stack>
+                </Stack>
+
+                <Box
+                    sx={{
+                        mt: { xs: 4, md: 5 },
+                        pt: 3,
+                        borderTop: "1px solid rgba(255,255,255,0.06)",
+                        display: "flex",
+                        flexDirection: { xs: "column", sm: "row" },
+                        justifyContent: "space-between",
+                        alignItems: { xs: "flex-start", sm: "center" },
+                        gap: 1.5,
+                        color: "rgba(255,255,255,0.4)",
+                        fontSize: "0.8rem",
+                    }}
+                >
+                    <Typography sx={{ fontSize: "inherit" }}>
+                        © {new Date().getFullYear()} Elixpo · Built on
+                        Cloudflare's edge
+                    </Typography>
+                    <Typography sx={{ fontSize: "inherit" }}>
+                        Open source · MIT
+                    </Typography>
+                </Box>
+            </Box>
+
+            <Snackbar
+                open={copied}
+                autoHideDuration={2200}
+                onClose={() => setCopied(false)}
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+                message={`Copied ${EMAIL} to clipboard`}
+            />
+        </Box>
+    );
+};
+
+export default Footer;

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -1,9 +1,21 @@
 "use client";
 
-import { AppBar, Box, Button, Chip, Toolbar, Typography } from "@mui/material";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import LoginIcon from "@mui/icons-material/Login";
+import {
+    AppBar,
+    Box,
+    Button,
+    Chip,
+    IconButton,
+    Toolbar,
+    Tooltip,
+    Typography,
+} from "@mui/material";
 import Link from "next/link";
 
 const ACCENT = "#9b7bf7";
+const REPO_URL = "https://github.com/elixpo/accounts.elixpo";
 
 const Navbar = () => (
     <AppBar
@@ -22,6 +34,7 @@ const Navbar = () => (
                 width: "100%",
                 mx: "auto",
                 px: { xs: 2, md: 4 },
+                minHeight: { xs: 60, md: 68 },
             }}
         >
             <Link
@@ -69,24 +82,68 @@ const Navbar = () => (
                 />
             </Link>
 
-            <Button
-                component={Link}
-                href="/login"
-                disableElevation
+            <Box
                 sx={{
-                    textTransform: "none",
-                    fontWeight: 600,
-                    fontSize: "0.9rem",
-                    color: "#fff",
-                    bgcolor: ACCENT,
-                    borderRadius: "8px",
-                    px: 2.2,
-                    py: 0.7,
-                    "&:hover": { bgcolor: "#b69aff" },
+                    display: "flex",
+                    alignItems: "center",
+                    gap: { xs: 1, md: 1.5 },
                 }}
             >
-                Sign in
-            </Button>
+                <Tooltip title="View source on GitHub" arrow>
+                    <IconButton
+                        component="a"
+                        href={REPO_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="View source on GitHub"
+                        sx={{
+                            color: "rgba(244,244,246,0.85)",
+                            border: "1px solid rgba(255,255,255,0.1)",
+                            borderRadius: "10px",
+                            width: 38,
+                            height: 38,
+                            transition: "all 0.18s ease",
+                            "&:hover": {
+                                color: "#fff",
+                                borderColor: "rgba(155,123,247,0.45)",
+                                background: "rgba(155,123,247,0.08)",
+                            },
+                        }}
+                    >
+                        <GitHubIcon sx={{ fontSize: 20 }} />
+                    </IconButton>
+                </Tooltip>
+
+                <Button
+                    component={Link}
+                    href="/login"
+                    disableElevation
+                    startIcon={
+                        <LoginIcon sx={{ fontSize: "1rem !important" }} />
+                    }
+                    sx={{
+                        textTransform: "none",
+                        fontWeight: 600,
+                        fontSize: "0.9rem",
+                        color: "#fff",
+                        background:
+                            "linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)",
+                        borderRadius: "10px",
+                        px: 2.4,
+                        py: 0.9,
+                        boxShadow: "0 4px 14px rgba(155,123,247,0.32)",
+                        transition: "all 0.2s ease",
+                        "&:hover": {
+                            background:
+                                "linear-gradient(135deg, #b094ff 0%, #8a6dff 100%)",
+                            boxShadow: "0 6px 20px rgba(155,123,247,0.45)",
+                            transform: "translateY(-1px)",
+                        },
+                    }}
+                >
+                    Sign in
+                </Button>
+            </Box>
         </Toolbar>
     </AppBar>
 );

--- a/app/dashboard/oauth-apps/page.tsx
+++ b/app/dashboard/oauth-apps/page.tsx
@@ -163,7 +163,7 @@ const OAuthAppsPage = () => {
     useEffect(() => {
         fetchApps();
         fetchVerificationStatus();
-    }, []);
+    }, [fetchVerificationStatus, fetchApps]);
 
     const fetchVerificationStatus = async () => {
         try {

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -302,7 +302,7 @@ const ProfilePage = () => {
         fetchProfile();
         fetchNotifPrefs();
         fetchConnectedServices();
-    }, []);
+    }, [fetchProfile, fetchNotifPrefs, fetchConnectedServices]);
 
     const fetchProfile = async () => {
         try {
@@ -794,13 +794,17 @@ const ProfilePage = () => {
                                     <Button
                                         size="small"
                                         onClick={() => {
-                                            setNewUsername(profile.username || "");
+                                            setNewUsername(
+                                                profile.username || "",
+                                            );
                                             setUsernameCheck({ state: "idle" });
                                             setUsernameMsg(null);
                                             setUsernameDialogOpen(true);
                                         }}
                                         startIcon={
-                                            <EditIcon sx={{ fontSize: "0.9rem" }} />
+                                            <EditIcon
+                                                sx={{ fontSize: "0.9rem" }}
+                                            />
                                         }
                                         sx={{
                                             color: "#9b7bf7",
@@ -2230,12 +2234,16 @@ const ProfilePage = () => {
                 <DialogContent>
                     <Alert
                         severity="warning"
-                        sx={{ mb: 2, bgcolor: "rgba(245,158,11,0.1)", color: "#f59e0b" }}
+                        sx={{
+                            mb: 2,
+                            bgcolor: "rgba(245,158,11,0.1)",
+                            color: "#f59e0b",
+                        }}
                     >
-                        This is destructive. Any link pointing to
-                        {" "}@{profile?.username} on other Elixpo services
-                        (profiles, shared blogs) will break. Your account and
-                        data stay the same.
+                        This is destructive. Any link pointing to @
+                        {profile?.username} on other Elixpo services (profiles,
+                        shared blogs) will break. Your account and data stay the
+                        same.
                     </Alert>
                     <TextField
                         fullWidth
@@ -2277,7 +2285,10 @@ const ProfilePage = () => {
                     <Button
                         onClick={() => setUsernameDialogOpen(false)}
                         disabled={usernameLoading}
-                        sx={{ color: "rgba(255,255,255,0.6)", textTransform: "none" }}
+                        sx={{
+                            color: "rgba(255,255,255,0.6)",
+                            textTransform: "none",
+                        }}
                     >
                         Cancel
                     </Button>

--- a/app/dashboard/services/page.tsx
+++ b/app/dashboard/services/page.tsx
@@ -82,6 +82,19 @@ function isSafeReturn(url: string): boolean {
     }
 }
 
+const getSafeReturnPath = (value: string | null): string | null => {
+    if (!value || typeof window === "undefined") return null;
+    try {
+        const url = new URL(value, window.location.origin);
+        const isHttp = url.protocol === "http:" || url.protocol === "https:";
+        if (!isHttp) return null;
+        if (url.origin !== window.location.origin) return null;
+        return `${url.pathname}${url.search}${url.hash}`;
+    } catch {
+        return null;
+    }
+};
+
 const ServicesPage = () => {
     const [services, setServices] = useState<ConnectedService[]>([]);
     const [loading, setLoading] = useState(true);
@@ -96,6 +109,7 @@ const ServicesPage = () => {
         const sp = new URLSearchParams(window.location.search);
         const revoke = sp.get("revoke");
         const returnTo = sp.get("return_to");
+        const safeReturnPath = getSafeReturnPath(returnTo);
         if (!revoke) return;
         setParamHandled(true);
 
@@ -108,8 +122,7 @@ const ServicesPage = () => {
         );
         if (!target) {
             // Not connected (or already revoked) — just send them back.
-            if (returnTo && isSafeReturn(returnTo))
-                window.location.href = returnTo;
+            if (safeReturnPath) window.location.href = safeReturnPath;
             return;
         }
         (async () => {
@@ -127,8 +140,8 @@ const ServicesPage = () => {
                     setServices((prev) =>
                         prev.filter((s) => s.client_id !== target.client_id),
                     );
-                    if (returnTo && isSafeReturn(returnTo)) {
-                        window.location.href = returnTo;
+                    if (safeReturnPath) {
+                        window.location.href = safeReturnPath;
                         return;
                     }
                 }

--- a/app/dashboard/services/page.tsx
+++ b/app/dashboard/services/page.tsx
@@ -70,7 +70,7 @@ function ServiceIcon({
 }
 
 // Only allow post-revoke redirects back to first-party elixpo.com hosts.
-function isSafeReturn(url: string): boolean {
+function _isSafeReturn(url: string): boolean {
     try {
         const u = new URL(url);
         return (

--- a/app/dashboard/services/page.tsx
+++ b/app/dashboard/services/page.tsx
@@ -108,7 +108,8 @@ const ServicesPage = () => {
         );
         if (!target) {
             // Not connected (or already revoked) — just send them back.
-            if (returnTo && isSafeReturn(returnTo)) window.location.href = returnTo;
+            if (returnTo && isSafeReturn(returnTo))
+                window.location.href = returnTo;
             return;
         }
         (async () => {
@@ -141,7 +142,7 @@ const ServicesPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
         fetchServices();
-    }, []);
+    }, [fetchServices]);
 
     const fetchServices = async () => {
         try {

--- a/app/dashboard/webhooks/[webhook_id]/page.tsx
+++ b/app/dashboard/webhooks/[webhook_id]/page.tsx
@@ -361,7 +361,9 @@ export default function WebhookDetailPage() {
                             border: "1px solid rgba(155, 123, 247,0.3)",
                             fontWeight: 600,
                             textTransform: "none",
-                            "&:hover": { background: "rgba(155, 123, 247,0.25)" },
+                            "&:hover": {
+                                background: "rgba(155, 123, 247,0.25)",
+                            },
                         }}
                     >
                         {saving ? "Saving..." : "Save Changes"}

--- a/app/dashboard/webhooks/page.tsx
+++ b/app/dashboard/webhooks/page.tsx
@@ -103,7 +103,7 @@ export default function WebhooksPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
         fetchWebhooks();
-    }, []);
+    }, [fetchWebhooks]);
 
     const fetchWebhooks = async () => {
         try {
@@ -254,7 +254,9 @@ export default function WebhooksPage() {
                             border: "1px solid rgba(155, 123, 247,0.3)",
                             fontWeight: 600,
                             textTransform: "none",
-                            "&:hover": { background: "rgba(155, 123, 247,0.25)" },
+                            "&:hover": {
+                                background: "rgba(155, 123, 247,0.25)",
+                            },
                         }}
                     >
                         Add Webhook
@@ -589,7 +591,9 @@ export default function WebhooksPage() {
                             background: "rgba(155, 123, 247,0.15)",
                             color: "#9b7bf7",
                             border: "1px solid rgba(155, 123, 247,0.3)",
-                            "&:hover": { background: "rgba(155, 123, 247,0.25)" },
+                            "&:hover": {
+                                background: "rgba(155, 123, 247,0.25)",
+                            },
                         }}
                     >
                         {creating ? "Creating..." : "Add Webhook"}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,26 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes auroraDriftA {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(6vmax, 4vmax) scale(1.08); }
+  66% { transform: translate(-4vmax, 7vmax) scale(0.94); }
+}
+
+@keyframes auroraDriftB {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(-5vmax, -6vmax) scale(1.05); }
+  66% { transform: translate(5vmax, -3vmax) scale(0.96); }
+}
+
+@keyframes auroraDriftC {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-46%, -54%) scale(1.1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes auroraDriftA { 0%, 100% { transform: none; } }
+  @keyframes auroraDriftB { 0%, 100% { transform: none; } }
+  @keyframes auroraDriftC { 0%, 100% { transform: translate(-50%, -50%); } }
+}

--- a/app/oauth/authorize/route.ts
+++ b/app/oauth/authorize/route.ts
@@ -143,7 +143,7 @@ export async function GET(request: NextRequest) {
 
         // Verify the token is valid
         const payload = await verifyJWT(accessToken);
-        if (!payload || payload.type !== "access") {
+        if (payload?.type !== "access") {
             // Token present but invalid/expired — same as not logged in
             const pendingParams = new URLSearchParams({
                 response_type: responseType,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,320 @@
 "use client";
 
-import { Box, CircularProgress } from "@mui/material";
-import { redirect } from "next/navigation";
-import { useEffect } from "react";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import BoltIcon from "@mui/icons-material/Bolt";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
+import HubIcon from "@mui/icons-material/Hub";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import Link from "next/link";
+import Navbar from "./components/navbar";
 
-export default function Home() {
-    useEffect(() => {
-        redirect("/login");
-    }, []);
+const ACCENT = "#9b7bf7";
 
+const FEATURES = [
+    {
+        icon: HubIcon,
+        title: "One account, everywhere",
+        body: "Sign in once and reach every Elixpo product — chat, art, blogs, clock, jackey, sketch — without juggling passwords.",
+    },
+    {
+        icon: FingerprintIcon,
+        title: "Passkey + WebAuthn",
+        body: "Phishing-resistant, passwordless login the moment your device supports it. Falls back gracefully to email and OAuth.",
+    },
+    {
+        icon: LockOutlinedIcon,
+        title: "OAuth 2.0 for integrators",
+        body: "A first-class Authorization Code flow with PKCE. Bring Elixpo identity to your own app in minutes.",
+    },
+    {
+        icon: BoltIcon,
+        title: "Edge-native, instant",
+        body: "Runs on Cloudflare's edge — sign-in checks complete in milliseconds, anywhere on the planet.",
+    },
+];
+
+export default function LandingPage() {
     return (
         <Box
             sx={{
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
                 minHeight: "100vh",
-                background: "linear-gradient(135deg, #1e2420 0%, #0f1117 100%)",
+                background:
+                    "linear-gradient(180deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
+                color: "#f5f5f4",
+                display: "flex",
+                flexDirection: "column",
             }}
         >
-            <CircularProgress sx={{ color: "#22c55e" }} size={60} />
+            <Navbar />
+
+            <Box
+                component="main"
+                sx={{
+                    flex: 1,
+                    maxWidth: "1200px",
+                    width: "100%",
+                    mx: "auto",
+                    px: { xs: 2.5, md: 4 },
+                    pt: { xs: 8, md: 14 },
+                    pb: { xs: 8, md: 12 },
+                }}
+            >
+                {/* Hero */}
+                <Stack
+                    spacing={3}
+                    alignItems="center"
+                    textAlign="center"
+                    sx={{ maxWidth: "820px", mx: "auto" }}
+                >
+                    <Chip
+                        label="The Elixpo identity layer"
+                        size="small"
+                        sx={{
+                            bgcolor: "rgba(155, 123, 247, 0.12)",
+                            color: ACCENT,
+                            border: "1px solid rgba(155, 123, 247, 0.3)",
+                            fontWeight: 600,
+                            letterSpacing: "0.04em",
+                            fontSize: "0.72rem",
+                            height: 26,
+                        }}
+                    />
+                    <Typography
+                        component="h1"
+                        sx={{
+                            fontWeight: 800,
+                            fontSize: { xs: "2.4rem", md: "3.6rem" },
+                            lineHeight: 1.08,
+                            letterSpacing: "-0.025em",
+                            background:
+                                "linear-gradient(180deg, #ffffff 0%, #c8c4d8 100%)",
+                            WebkitBackgroundClip: "text",
+                            WebkitTextFillColor: "transparent",
+                        }}
+                    >
+                        One sign-in for the whole{" "}
+                        <Box component="span" sx={{ color: ACCENT }}>
+                            Elixpo ecosystem.
+                        </Box>
+                    </Typography>
+                    <Typography
+                        sx={{
+                            color: "rgba(255,255,255,0.65)",
+                            fontSize: { xs: "1rem", md: "1.15rem" },
+                            maxWidth: "640px",
+                            lineHeight: 1.55,
+                        }}
+                    >
+                        Secure OAuth 2.0 single sign-on built on the edge. Use
+                        one account across every Elixpo product, and let your
+                        own apps tap into the same identity in minutes.
+                    </Typography>
+
+                    <Stack
+                        direction={{ xs: "column", sm: "row" }}
+                        spacing={1.5}
+                        sx={{ pt: 1 }}
+                    >
+                        <Button
+                            component={Link}
+                            href="/login"
+                            endIcon={<ArrowForwardIcon />}
+                            sx={{
+                                textTransform: "none",
+                                fontWeight: 600,
+                                fontSize: "1rem",
+                                color: "#fff",
+                                background:
+                                    "linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)",
+                                borderRadius: "12px",
+                                px: 3,
+                                py: 1.3,
+                                boxShadow: "0 8px 24px rgba(155,123,247,0.35)",
+                                transition: "all 0.2s ease",
+                                "&:hover": {
+                                    background:
+                                        "linear-gradient(135deg, #b094ff 0%, #8a6dff 100%)",
+                                    boxShadow:
+                                        "0 12px 32px rgba(155,123,247,0.5)",
+                                    transform: "translateY(-1px)",
+                                },
+                            }}
+                        >
+                            Get started
+                        </Button>
+                        <Button
+                            component={Link}
+                            href="/docs"
+                            sx={{
+                                textTransform: "none",
+                                fontWeight: 500,
+                                fontSize: "1rem",
+                                color: "rgba(255,255,255,0.85)",
+                                border: "1px solid rgba(255,255,255,0.12)",
+                                borderRadius: "12px",
+                                px: 3,
+                                py: 1.3,
+                                "&:hover": {
+                                    borderColor: "rgba(155,123,247,0.4)",
+                                    background: "rgba(255,255,255,0.04)",
+                                },
+                            }}
+                        >
+                            Integrator docs
+                        </Button>
+                    </Stack>
+                </Stack>
+
+                {/* Features */}
+                <Box
+                    sx={{
+                        display: "grid",
+                        gridTemplateColumns: {
+                            xs: "1fr",
+                            sm: "1fr 1fr",
+                        },
+                        gap: 2.5,
+                        mt: { xs: 8, md: 12 },
+                    }}
+                >
+                    {FEATURES.map(({ icon: Icon, title, body }) => (
+                        <Box
+                            key={title}
+                            sx={{
+                                p: 3,
+                                borderRadius: "16px",
+                                background:
+                                    "linear-gradient(135deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.015) 100%)",
+                                border: "1px solid rgba(255,255,255,0.08)",
+                                backdropFilter: "blur(20px)",
+                                transition: "border-color 0.2s ease",
+                                "&:hover": {
+                                    borderColor: "rgba(155,123,247,0.3)",
+                                },
+                            }}
+                        >
+                            <Box
+                                sx={{
+                                    display: "inline-flex",
+                                    p: 1.1,
+                                    borderRadius: "10px",
+                                    background: "rgba(155,123,247,0.12)",
+                                    border: "1px solid rgba(155,123,247,0.25)",
+                                    mb: 2,
+                                }}
+                            >
+                                <Icon sx={{ color: ACCENT, fontSize: 22 }} />
+                            </Box>
+                            <Typography
+                                sx={{
+                                    fontWeight: 700,
+                                    fontSize: "1.05rem",
+                                    color: "#f5f5f4",
+                                    mb: 0.8,
+                                }}
+                            >
+                                {title}
+                            </Typography>
+                            <Typography
+                                sx={{
+                                    color: "rgba(255,255,255,0.6)",
+                                    fontSize: "0.92rem",
+                                    lineHeight: 1.55,
+                                }}
+                            >
+                                {body}
+                            </Typography>
+                        </Box>
+                    ))}
+                </Box>
+
+                {/* CTA */}
+                <Box
+                    sx={{
+                        mt: { xs: 8, md: 12 },
+                        p: { xs: 4, md: 5 },
+                        borderRadius: "20px",
+                        background:
+                            "linear-gradient(135deg, rgba(155,123,247,0.12) 0%, rgba(124,92,255,0.05) 100%)",
+                        border: "1px solid rgba(155,123,247,0.25)",
+                        textAlign: "center",
+                    }}
+                >
+                    <Typography
+                        sx={{
+                            fontWeight: 700,
+                            fontSize: { xs: "1.5rem", md: "1.9rem" },
+                            color: "#f5f5f4",
+                            mb: 1.2,
+                            letterSpacing: "-0.015em",
+                        }}
+                    >
+                        Ready when you are.
+                    </Typography>
+                    <Typography
+                        sx={{
+                            color: "rgba(255,255,255,0.65)",
+                            fontSize: "1rem",
+                            mb: 3,
+                            maxWidth: "520px",
+                            mx: "auto",
+                        }}
+                    >
+                        Create an account in seconds, or sign in if you already
+                        have one. Your identity carries across every Elixpo
+                        product automatically.
+                    </Typography>
+                    <Button
+                        component={Link}
+                        href="/login"
+                        endIcon={<ArrowForwardIcon />}
+                        sx={{
+                            textTransform: "none",
+                            fontWeight: 600,
+                            fontSize: "1rem",
+                            color: "#fff",
+                            background:
+                                "linear-gradient(135deg, #9b7bf7 0%, #7c5cff 100%)",
+                            borderRadius: "12px",
+                            px: 3.2,
+                            py: 1.3,
+                            boxShadow: "0 8px 24px rgba(155,123,247,0.35)",
+                            "&:hover": {
+                                background:
+                                    "linear-gradient(135deg, #b094ff 0%, #8a6dff 100%)",
+                                boxShadow:
+                                    "0 12px 32px rgba(155,123,247,0.5)",
+                                transform: "translateY(-1px)",
+                            },
+                        }}
+                    >
+                        Continue to sign in
+                    </Button>
+                </Box>
+            </Box>
+
+            {/* Footer */}
+            <Box
+                component="footer"
+                sx={{
+                    borderTop: "1px solid rgba(255,255,255,0.06)",
+                    py: 3,
+                    px: { xs: 2.5, md: 4 },
+                    color: "rgba(255,255,255,0.45)",
+                    fontSize: "0.85rem",
+                    textAlign: "center",
+                }}
+            >
+                © {new Date().getFullYear()} Elixpo · Built on Cloudflare's
+                edge ·{" "}
+                <Link
+                    href="/about"
+                    style={{ color: "rgba(255,255,255,0.7)" }}
+                >
+                    About
+                </Link>
+            </Box>
         </Box>
     );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import HubIcon from "@mui/icons-material/Hub";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import Link from "next/link";
+import BackgroundAurora from "./components/background-aurora";
 import Navbar from "./components/navbar";
 
 const ACCENT = "#9b7bf7";
@@ -14,23 +15,27 @@ const ACCENT = "#9b7bf7";
 const FEATURES = [
     {
         icon: HubIcon,
-        title: "One account, everywhere",
-        body: "Sign in once and reach every Elixpo product — chat, art, blogs, clock, jackey, sketch — without juggling passwords.",
+        title: "One identity, any app",
+        body: "Use a single account across the Elixpo ecosystem and any third-party app that adopts our OAuth — no juggling passwords.",
+        soon: false,
     },
     {
         icon: FingerprintIcon,
         title: "Passkey + WebAuthn",
-        body: "Phishing-resistant, passwordless login the moment your device supports it. Falls back gracefully to email and OAuth.",
+        body: "Phishing-resistant, passwordless sign-in is on the way. For now you can use email + password or social providers.",
+        soon: true,
     },
     {
         icon: LockOutlinedIcon,
-        title: "OAuth 2.0 for integrators",
-        body: "A first-class Authorization Code flow with PKCE. Bring Elixpo identity to your own app in minutes.",
+        title: "OAuth 2.0 for everyone",
+        body: "A first-class Authorization Code flow with PKCE. Drop our SSO into your own product in minutes — Elixpo or not.",
+        soon: false,
     },
     {
         icon: BoltIcon,
         title: "Edge-native, instant",
         body: "Runs on Cloudflare's edge — sign-in checks complete in milliseconds, anywhere on the planet.",
+        soon: false,
     },
 ];
 
@@ -39,14 +44,17 @@ export default function LandingPage() {
         <Box
             sx={{
                 minHeight: "100vh",
-                background:
-                    "linear-gradient(180deg, #0f1117 0%, #131922 50%, #0f1117 100%)",
                 color: "#f5f5f4",
                 display: "flex",
                 flexDirection: "column",
+                position: "relative",
             }}
         >
-            <Navbar />
+            <BackgroundAurora variant="default" />
+
+            <Box sx={{ position: "relative", zIndex: 1 }}>
+                <Navbar />
+            </Box>
 
             <Box
                 component="main"
@@ -56,11 +64,12 @@ export default function LandingPage() {
                     width: "100%",
                     mx: "auto",
                     px: { xs: 2.5, md: 4 },
-                    pt: { xs: 8, md: 14 },
+                    pt: { xs: 4, md: 6 },
                     pb: { xs: 8, md: 12 },
+                    position: "relative",
+                    zIndex: 1,
                 }}
             >
-                {/* Hero */}
                 <Stack
                     spacing={3}
                     alignItems="center"
@@ -68,7 +77,7 @@ export default function LandingPage() {
                     sx={{ maxWidth: "820px", mx: "auto" }}
                 >
                     <Chip
-                        label="The Elixpo identity layer"
+                        label="Open SSO for any app"
                         size="small"
                         sx={{
                             bgcolor: "rgba(155, 123, 247, 0.12)",
@@ -93,9 +102,9 @@ export default function LandingPage() {
                             WebkitTextFillColor: "transparent",
                         }}
                     >
-                        One sign-in for the whole{" "}
+                        One sign-in.{" "}
                         <Box component="span" sx={{ color: ACCENT }}>
-                            Elixpo ecosystem.
+                            Every app you ship.
                         </Box>
                     </Typography>
                     <Typography
@@ -104,11 +113,13 @@ export default function LandingPage() {
                             fontSize: { xs: "1rem", md: "1.15rem" },
                             maxWidth: "640px",
                             lineHeight: 1.55,
+                            fontFamily: "var(--font-geist-sans)",
                         }}
                     >
-                        Secure OAuth 2.0 single sign-on built on the edge. Use
-                        one account across every Elixpo product, and let your
-                        own apps tap into the same identity in minutes.
+                        Secure OAuth 2.0 single sign-on built on the edge. Born
+                        inside the Elixpo ecosystem, open for any product or
+                        developer to use — drop it into your app and let users
+                        sign in in seconds.
                     </Typography>
 
                     <Stack
@@ -166,7 +177,6 @@ export default function LandingPage() {
                     </Stack>
                 </Stack>
 
-                {/* Features */}
                 <Box
                     sx={{
                         display: "grid",
@@ -175,17 +185,18 @@ export default function LandingPage() {
                             sm: "1fr 1fr",
                         },
                         gap: 2.5,
-                        mt: { xs: 8, md: 12 },
+                        mt: { xs: 7, md: 10 },
                     }}
                 >
-                    {FEATURES.map(({ icon: Icon, title, body }) => (
+                    {FEATURES.map(({ icon: Icon, title, body, soon }) => (
                         <Box
                             key={title}
                             sx={{
+                                position: "relative",
                                 p: 3,
                                 borderRadius: "16px",
                                 background:
-                                    "linear-gradient(135deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.015) 100%)",
+                                    "linear-gradient(135deg, rgba(255,255,255,0.045) 0%, rgba(255,255,255,0.015) 100%)",
                                 border: "1px solid rgba(255,255,255,0.08)",
                                 backdropFilter: "blur(20px)",
                                 transition: "border-color 0.2s ease",
@@ -196,15 +207,40 @@ export default function LandingPage() {
                         >
                             <Box
                                 sx={{
-                                    display: "inline-flex",
-                                    p: 1.1,
-                                    borderRadius: "10px",
-                                    background: "rgba(155,123,247,0.12)",
-                                    border: "1px solid rgba(155,123,247,0.25)",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "space-between",
                                     mb: 2,
                                 }}
                             >
-                                <Icon sx={{ color: ACCENT, fontSize: 22 }} />
+                                <Box
+                                    sx={{
+                                        display: "inline-flex",
+                                        p: 1.1,
+                                        borderRadius: "10px",
+                                        background: "rgba(155,123,247,0.12)",
+                                        border: "1px solid rgba(155,123,247,0.25)",
+                                    }}
+                                >
+                                    <Icon
+                                        sx={{ color: ACCENT, fontSize: 22 }}
+                                    />
+                                </Box>
+                                {soon && (
+                                    <Chip
+                                        label="Coming soon"
+                                        size="small"
+                                        sx={{
+                                            bgcolor: "rgba(255,255,255,0.06)",
+                                            color: "rgba(255,255,255,0.7)",
+                                            border: "1px solid rgba(255,255,255,0.12)",
+                                            fontWeight: 600,
+                                            fontSize: "0.68rem",
+                                            letterSpacing: "0.04em",
+                                            height: 22,
+                                        }}
+                                    />
+                                )}
                             </Box>
                             <Typography
                                 sx={{
@@ -212,15 +248,17 @@ export default function LandingPage() {
                                     fontSize: "1.05rem",
                                     color: "#f5f5f4",
                                     mb: 0.8,
+                                    fontFamily: "var(--font-geist-sans)",
                                 }}
                             >
                                 {title}
                             </Typography>
                             <Typography
                                 sx={{
-                                    color: "rgba(255,255,255,0.6)",
+                                    color: "rgba(255,255,255,0.62)",
                                     fontSize: "0.92rem",
                                     lineHeight: 1.55,
+                                    fontFamily: "var(--font-geist-mono)",
                                 }}
                             >
                                 {body}
@@ -229,14 +267,13 @@ export default function LandingPage() {
                     ))}
                 </Box>
 
-                {/* CTA */}
                 <Box
                     sx={{
                         mt: { xs: 8, md: 12 },
                         p: { xs: 4, md: 5 },
                         borderRadius: "20px",
                         background:
-                            "linear-gradient(135deg, rgba(155,123,247,0.12) 0%, rgba(124,92,255,0.05) 100%)",
+                            "linear-gradient(135deg, rgba(155,123,247,0.14) 0%, rgba(95,182,255,0.06) 100%)",
                         border: "1px solid rgba(155,123,247,0.25)",
                         textAlign: "center",
                     }}
@@ -261,9 +298,9 @@ export default function LandingPage() {
                             mx: "auto",
                         }}
                     >
-                        Create an account in seconds, or sign in if you already
-                        have one. Your identity carries across every Elixpo
-                        product automatically.
+                        Create an account in seconds or sign in if you already
+                        have one. The same identity works across Elixpo and any
+                        app integrating our SSO.
                     </Typography>
                     <Button
                         component={Link}
@@ -293,7 +330,6 @@ export default function LandingPage() {
                 </Box>
             </Box>
 
-            {/* Footer */}
             <Box
                 component="footer"
                 sx={{
@@ -303,6 +339,8 @@ export default function LandingPage() {
                     color: "rgba(255,255,255,0.45)",
                     fontSize: "0.85rem",
                     textAlign: "center",
+                    position: "relative",
+                    zIndex: 1,
                 }}
             >
                 © {new Date().getFullYear()} Elixpo · Built on Cloudflare's edge

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import Link from "next/link";
 import BackgroundAurora from "./components/background-aurora";
+import Footer from "./components/footer";
 import Navbar from "./components/navbar";
 
 const ACCENT = "#9b7bf7";
@@ -330,25 +331,7 @@ export default function LandingPage() {
                 </Box>
             </Box>
 
-            <Box
-                component="footer"
-                sx={{
-                    borderTop: "1px solid rgba(255,255,255,0.06)",
-                    py: 3,
-                    px: { xs: 2.5, md: 4 },
-                    color: "rgba(255,255,255,0.45)",
-                    fontSize: "0.85rem",
-                    textAlign: "center",
-                    position: "relative",
-                    zIndex: 1,
-                }}
-            >
-                © {new Date().getFullYear()} Elixpo · Built on Cloudflare's edge
-                ·{" "}
-                <Link href="/about" style={{ color: "rgba(255,255,255,0.7)" }}>
-                    About
-                </Link>
-            </Box>
+            <Footer />
         </Box>
     );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -283,8 +283,7 @@ export default function LandingPage() {
                             "&:hover": {
                                 background:
                                     "linear-gradient(135deg, #b094ff 0%, #8a6dff 100%)",
-                                boxShadow:
-                                    "0 12px 32px rgba(155,123,247,0.5)",
+                                boxShadow: "0 12px 32px rgba(155,123,247,0.5)",
                                 transform: "translateY(-1px)",
                             },
                         }}
@@ -306,12 +305,9 @@ export default function LandingPage() {
                     textAlign: "center",
                 }}
             >
-                © {new Date().getFullYear()} Elixpo · Built on Cloudflare's
-                edge ·{" "}
-                <Link
-                    href="/about"
-                    style={{ color: "rgba(255,255,255,0.7)" }}
-                >
+                © {new Date().getFullYear()} Elixpo · Built on Cloudflare's edge
+                ·{" "}
+                <Link href="/about" style={{ color: "rgba(255,255,255,0.7)" }}>
                     About
                 </Link>
             </Box>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import Link from "next/link";
 import BackgroundAurora from "./components/background-aurora";
+import Footer from "./components/footer";
 import Navbar from "./components/navbar";
 
 const ACCENT = "#9b7bf7";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,6 @@ import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import Link from "next/link";
 import BackgroundAurora from "./components/background-aurora";
-import Footer from "./components/footer";
 import Navbar from "./components/navbar";
 
 const ACCENT = "#9b7bf7";

--- a/app/setup-name/page.tsx
+++ b/app/setup-name/page.tsx
@@ -81,7 +81,7 @@ const SetupNameContent = () => {
             }
         })();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [router.push, next]);
 
     // Debounced availability check.
     useEffect(() => {
@@ -113,11 +113,19 @@ const SetupNameContent = () => {
         const dn = displayName.trim();
         const handle = username.trim().toLowerCase();
         if (dn.length < 2 || dn.length > 32) {
-            setToast({ open: true, message: "Display name must be 2-32 characters.", severity: "error" });
+            setToast({
+                open: true,
+                message: "Display name must be 2-32 characters.",
+                severity: "error",
+            });
             return;
         }
         if (check.state !== "available") {
-            setToast({ open: true, message: check.reason || "Pick an available username.", severity: "error" });
+            setToast({
+                open: true,
+                message: check.reason || "Pick an available username.",
+                severity: "error",
+            });
             return;
         }
 
@@ -230,18 +238,26 @@ const SetupNameContent = () => {
                     value={username}
                     onChange={(e) =>
                         setUsername(
-                            e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ""),
+                            e.target.value
+                                .toLowerCase()
+                                .replace(/[^a-z0-9_-]/g, ""),
                         )
                     }
                     placeholder="e.g. anwesha, swift-fox"
                     helperText={handleHelper}
-                    FormHelperTextProps={{ sx: { color: `${handleHelperColor} !important` } }}
+                    FormHelperTextProps={{
+                        sx: { color: `${handleHelperColor} !important` },
+                    }}
                     sx={{ ...textFieldSx, mb: 2.5 }}
                     disabled={loading}
                     inputProps={{ maxLength: 32 }}
                     InputProps={{
                         startAdornment: (
-                            <Typography sx={{ color: "rgba(255,255,255,0.4)", mr: 0.5 }}>@</Typography>
+                            <Typography
+                                sx={{ color: "rgba(255,255,255,0.4)", mr: 0.5 }}
+                            >
+                                @
+                            </Typography>
                         ),
                     }}
                 />

--- a/src/lib/admin-middleware.ts
+++ b/src/lib/admin-middleware.ts
@@ -26,7 +26,7 @@ export async function verifyAdminSession(
         }
 
         const payload = await verifyJWT(token);
-        if (!payload || payload.type !== "access") {
+        if (payload?.type !== "access") {
             return null;
         }
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -341,7 +341,7 @@ export const emailTemplates = {
       </div>
       `
               : ""
-      }
+}
 
       <div class="notice">
         <p><strong>Security notice:</strong> Do not share this code with anyone. Elixpo staff will never ask for your verification code by phone, email, or chat.</p>

--- a/src/lib/revocation-webhook.ts
+++ b/src/lib/revocation-webhook.ts
@@ -56,7 +56,12 @@ export async function fireRevocationWebhook(
     if (!target) return false;
 
     const timestamp = new Date().toISOString();
-    const payload = JSON.stringify({ event, user_id: userId, client_id: clientId, timestamp });
+    const payload = JSON.stringify({
+        event,
+        user_id: userId,
+        client_id: clientId,
+        timestamp,
+    });
 
     try {
         const signature = await hmacHex(payload, target.secret);

--- a/src/lib/smtp-client.ts
+++ b/src/lib/smtp-client.ts
@@ -33,7 +33,7 @@ class SmtpConnection {
     private encoder = new TextEncoder();
 
     async connect(config: SmtpConfig): Promise<void> {
-        // @ts-ignore — cloudflare:sockets is a Cloudflare Workers built-in module
+        // @ts-expect-error — cloudflare:sockets is a Cloudflare Workers built-in module
         const { connect } = await import(
             /* webpackIgnore: true */ "cloudflare:sockets"
         );
@@ -60,7 +60,7 @@ class SmtpConnection {
             const starttls = await this.command("STARTTLS");
             if (starttls.code !== 220)
                 throw new Error(`SMTP STARTTLS failed: ${starttls.text}`);
-            // @ts-ignore
+            // @ts-expect-error
             this.socket = this.socket.startTls();
             this.reader = this.socket.readable.getReader();
             this.writer = this.socket.writable.getWriter();

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -7,11 +7,39 @@ const USERNAME_RE = /^[a-z0-9](?:[a-z0-9]|[-_](?![-_])){1,30}[a-z0-9]$/;
 
 // Reserved handles that collide with routes or are confusing as profiles.
 const RESERVED = new Set([
-    "admin", "administrator", "root", "api", "oauth", "sso", "auth",
-    "dashboard", "login", "logout", "register", "signup", "signin",
-    "settings", "setup-name", "verify", "callback", "authorize", "me",
-    "profile", "user", "users", "account", "accounts", "elixpo", "support",
-    "help", "about", "docs", "null", "undefined", "system", "staff",
+    "admin",
+    "administrator",
+    "root",
+    "api",
+    "oauth",
+    "sso",
+    "auth",
+    "dashboard",
+    "login",
+    "logout",
+    "register",
+    "signup",
+    "signin",
+    "settings",
+    "setup-name",
+    "verify",
+    "callback",
+    "authorize",
+    "me",
+    "profile",
+    "user",
+    "users",
+    "account",
+    "accounts",
+    "elixpo",
+    "support",
+    "help",
+    "about",
+    "docs",
+    "null",
+    "undefined",
+    "system",
+    "staff",
 ]);
 
 export function normalizeUsername(raw: string): string {
@@ -23,14 +51,20 @@ export function validateUsername(
     raw: string,
 ): { ok: true; value: string } | { ok: false; reason: string } {
     const value = normalizeUsername(raw);
-    if (value.length < 3) return { ok: false, reason: "Username must be at least 3 characters." };
-    if (value.length > 32) return { ok: false, reason: "Username must be 32 characters or fewer." };
+    if (value.length < 3)
+        return { ok: false, reason: "Username must be at least 3 characters." };
+    if (value.length > 32)
+        return {
+            ok: false,
+            reason: "Username must be 32 characters or fewer.",
+        };
     if (!USERNAME_RE.test(value)) {
         return {
             ok: false,
             reason: "Use lowercase letters, numbers, - and _ only; start and end with a letter or number.",
         };
     }
-    if (RESERVED.has(value)) return { ok: false, reason: "That username is reserved." };
+    if (RESERVED.has(value))
+        return { ok: false, reason: "That username is reserved." };
     return { ok: true, value };
 }

--- a/types/validator.ts
+++ b/types/validator.ts
@@ -58,7 +58,7 @@ type LayoutConfig<Route extends LayoutRoutes = LayoutRoutes> = {
     type __IsExpected<Specific extends AppPageConfig<"/">> = Specific;
     const handler = {} as typeof import("../app/page.tsx");
     type __Check = __IsExpected<typeof handler>;
-    // @ts-ignore
+    // @ts-expect-error
     type __Unused = __Check;
 }
 
@@ -67,6 +67,6 @@ type LayoutConfig<Route extends LayoutRoutes = LayoutRoutes> = {
     type __IsExpected<Specific extends LayoutConfig<"/">> = Specific;
     const handler = {} as typeof import("../app/layout.tsx");
     type __Check = __IsExpected<typeof handler>;
-    // @ts-ignore
+    // @ts-expect-error
     type __Unused = __Check;
 }


### PR DESCRIPTION
## Changes Made

- Replaced the auto-redirect to `/login` in `app/page.tsx` with a full landing page — hero, features grid, CTA card, and footer — so unauthenticated visitors see content instead of being bounced immediately.
- Added four feature cards (SSO, Passkey/WebAuthn, OAuth 2.0, Edge-native) in `app/page.tsx` to communicate platform capabilities upfront.
- Redesigned the sign-in button in `app/components/navbar.tsx` with a gradient background, `LoginIcon` start icon, shadow, and hover lift for better visual hierarchy.
- Added a GitHub repository icon link with `Tooltip` in `app/components/navbar.tsx` so visitors can find the source from the landing page.
- Set responsive `minHeight` on the `Toolbar` in `app/components/navbar.tsx` to keep navbar height consistent across breakpoints.
- Wrapped the right-side navbar actions in a flex `Box` in `app/components/navbar.tsx` to properly space the GitHub icon and sign-in button.

## Checklist

- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>